### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,9 +6,9 @@
 # Datatypes (KEYWORD1)
 #######################################
 LM35	KEYWORD1
-CELCIUS KEYWORD1
-KELVIN KEYWORD1
-FAHRENHEIT KEYWORD1
+CELCIUS	KEYWORD1
+KELVIN	KEYWORD1
+FAHRENHEIT	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords